### PR TITLE
Log if the generated Python output file is missing

### DIFF
--- a/pythontex/pythontex.dtx
+++ b/pythontex/pythontex.dtx
@@ -2141,7 +2141,9 @@
 %    \begin{macrocode}
 \AtBeginDocument{%
     \makeatletter
-    \InputIfFileExists{\pytx@outputdir/\pytx@jobname.pytxmcr}{}{}%
+    \IfFileExists{\pytx@outputdir/\pytx@jobname.pytxmcr}{%
+        \input{\pytx@outputdir/\pytx@jobname.pytxmcr}{}{}}{%
+        \typeout{No file \pytx@outputdir/\pytx@jobname.pytxmcr.}}%
     \makeatother
 }
 %    \end{macrocode}

--- a/pythontex/pythontex.sty
+++ b/pythontex/pythontex.sty
@@ -315,7 +315,9 @@
 }
 \AtBeginDocument{%
     \makeatletter
-    \InputIfFileExists{\pytx@outputdir/\pytx@jobname.pytxmcr}{}{}%
+    \IfFileExists{\pytx@outputdir/\pytx@jobname.pytxmcr}{%
+        \input{\pytx@outputdir/\pytx@jobname.pytxmcr}{}{}}{%
+        \typeout{No file \pytx@outputdir/\pytx@jobname.pytxmcr.}}%
     \makeatother
 }
 \newwrite\pytx@codefile


### PR DESCRIPTION
When the package expects Python output to be present, it attempts to input the .pytxmcr file. If this file is not found, nothing was done, expecting the user to know that pythontex.py should be run.

This patch prints a message to the log which enables scripts such as latexmk to deduce that a file is missing and run pythontex.py automatically to create it (and re-run latex on the original document afterwards).

Such a dependency can be setup if you add the following lines to your latexmkrc:

```
add_cus_dep('pytxcode','pytxmcr',0,'pythontex');
sub pythontex { return system("pythontex.py \"$_[0]\""); }
```

When latexmk sees that the .pytxmcr file is missing, it will make it from .pytxcode. When changes are detected for the .pytxcode, it will re-run pythontex.py to update the .pytxmcr file.

Currently, this requires you to specify

```
\setpythontexoutputdir{.}
```

so that the .pytxmcr file is expected to be in the same directory as the .pytxcode, as this is the only place latexmk will look for it.
