### PR TITLE
Check if currfile package is already loaded

### DIFF
--- a/pythontex/pythontex.sty
+++ b/pythontex/pythontex.sty
@@ -5,9 +5,9 @@
 %% The original source files were:
 %%
 %% pythontex.dtx  (with options: `package')
-%% 
+%%
 %% This is a generated file.
-%% 
+%%
 %% Copyright (C) 2012-2014 by Geoffrey M. Poore <gpoore@gmail.com>
 %% --------------------------------------------------------------------------
 %% This work may be distributed and/or modified under the
@@ -17,7 +17,7 @@
 %%   http://www.latex-project.org/lppl.txt
 %% and version 1.3 or later is part of all distributions of LaTeX
 %% version 2005/12/01 or later.
-%% 
+%%
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesPackage{pythontex}
     [2014/07/17 Version~0.14 ]
@@ -30,7 +30,7 @@
 \RequirePackage{xstring}
 \RequirePackage{pgfopts}
 \RequirePackage{newfloat}
-\RequirePackage{currfile}
+\@ifpackageloaded{currfile}{}{\RequirePackage{currfile}}
 \AtBeginDocument{\@ifpackageloaded{color}{}{\RequirePackage{xcolor}}}
 \def\pytx@families{}
 \pgfkeys{/PYTX/pkgopt/usefamily/.estore in=\pytx@families}


### PR DESCRIPTION
This change avoids the "Option clash for package currfile." error thrown by PythonTeX when loading currfile package with non-default options before it.