### PR TITLE
Support for platforms where multiprocessing does not work

### DIFF
--- a/pythontex/pythontex3.py
+++ b/pythontex/pythontex3.py
@@ -1324,35 +1324,23 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
     for key in cons_dict:
         family = key.split('#')[0]
         if engine_dict[family].language.startswith('python'):
-            if family in pygments_settings:
-                # Uncomment the following for debugging
-                '''python_console(jobname, encoding, outputdir, workingdir,
-                               fvextfile, pygments_settings[family],
-                               cc_dict_begin[family], cons_dict[key],
-                               cc_dict_end[family], engine_dict[family].startup,
-                               engine_dict[family].banner,
-                               engine_dict[family].filename)'''
-                tasks.append(pool.apply_async(python_console, [jobname, encoding,
-                                                               outputdir, workingdir,
-                                                               fvextfile,
-                                                               pygments_settings[family],
-                                                               cc_dict_begin[family],
-                                                               cons_dict[key],
-                                                               cc_dict_end[family],
-                                                               engine_dict[family].startup,
-                                                               engine_dict[family].banner,
-                                                               engine_dict[family].filename]))
-            else:
-                tasks.append(pool.apply_async(python_console, [jobname, encoding,
-                                                               outputdir, workingdir,
-                                                               fvextfile,
-                                                               None,
-                                                               cc_dict_begin[family],
-                                                               cons_dict[key],
-                                                               cc_dict_end[family],
-                                                               engine_dict[family].startup,
-                                                               engine_dict[family].banner,
-                                                               engine_dict[family].filename]))
+            # Uncomment the following for debugging
+            '''python_console(jobname, encoding, outputdir, workingdir,
+                           fvextfile, pygments_settings[family],
+                           cc_dict_begin[family], cons_dict[key],
+                           cc_dict_end[family], engine_dict[family].startup,
+                           engine_dict[family].banner,
+                           engine_dict[family].filename)'''
+            tasks.append(pool.apply_async(python_console, [jobname, encoding,
+                                                           outputdir, workingdir,
+                                                           fvextfile,
+                                                           pygments_settings[family] if family in pygments_settings else None,
+                                                           cc_dict_begin[family],
+                                                           cons_dict[key],
+                                                           cc_dict_end[family],
+                                                           engine_dict[family].startup,
+                                                           engine_dict[family].banner,
+                                                           engine_dict[family].filename]))
         else:
             print('* PythonTeX error')
             print('    Currently, non-Python consoles are not supported')

--- a/pythontex/pythontex3.py
+++ b/pythontex/pythontex3.py
@@ -57,12 +57,18 @@ from hashlib import sha1
 from collections import defaultdict, OrderedDict, namedtuple
 from re import match, sub, search
 import subprocess
-import multiprocessing
 from pygments.styles import get_all_styles
 from pythontex_engines import *
 import textwrap
 import platform
 import itertools
+
+try:
+    import multiprocessing.synchronize  # noqa: F401
+    from multiprocessing import Pool
+except ImportError:
+    multiprocessing = False
+
 
 if sys.version_info[0] == 2:
     try:
@@ -192,8 +198,9 @@ def process_argv(data, temp_data):
         temp_data['hashdependencies'] = False
     if args.jobs is None:
         try:
-            jobs = multiprocessing.cpu_count()
+            jobs = os.cpu_count()
         except NotImplementedError:
+            # Is this exception needed with os.cpu_count?
             jobs = 1
         temp_data['jobs'] = jobs
     else:
@@ -1145,6 +1152,13 @@ def parse_code_write_scripts(data, temp_data, engine_dict):
 
 
 
+def eval_task(fun_name, arg_list):
+    '''
+    Some platforms, like android, does not support multiprocessing. For such
+    platforms we fall back to this function when running tasks.
+    '''
+    arg_tuple = tuple(arg_list)
+    return eval(fun_name)(*arg_tuple)
 
 def do_multiprocessing(data, temp_data, old_data, engine_dict):
     jobname = data['jobname']
@@ -1269,7 +1283,14 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
     # concurrent processes to a user-specified value for jobs.  If the user
     # has not specified a value, then it will be None, and
     # multiprocessing.Pool() will use cpu_count().
-    pool = multiprocessing.Pool(jobs)
+    if multiprocessing:
+        pool = Pool(jobs)
+        # Add task to list of tasks to run asynchronously, from function
+        # name and list of args.
+        # globals()[fun] converts string with function name into function handle
+        async_or_eval = lambda fun, args: pool.apply_async(globals()[fun], args)
+    else:
+        async_or_eval = eval_task
     tasks = []
 
     # If verbose, print a list of processes
@@ -1284,39 +1305,39 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
         family = key.split('#')[0]
         # Uncomment the following for debugging, and comment out what follows
         '''run_code(encoding, outputdir,
-                                                 workingdir,
-                                                 cc_dict_begin[family],
-                                                 code_dict[key],
-                                                 cc_dict_end[family],
-                                                 engine_dict[family].language,
-                                                 engine_dict[family].commands,
-                                                 engine_dict[family].created,
-                                                 engine_dict[family].extension,
-                                                 makestderr, stderrfilename,
-                                                 code_index_dict[key],
-                                                 engine_dict[family].errors,
-                                                 engine_dict[family].warnings,
-                                                 engine_dict[family].linenumbers,
-                                                 engine_dict[family].lookbehind,
-                                                 keeptemps, hashdependencies,
-                                                 pygments_settings)'''
-        tasks.append(pool.apply_async(run_code, [encoding, outputdir,
-                                                 workingdir,
-                                                 cc_dict_begin[family],
-                                                 code_dict[key],
-                                                 cc_dict_end[family],
-                                                 engine_dict[family].language,
-                                                 engine_dict[family].commands,
-                                                 engine_dict[family].created,
-                                                 engine_dict[family].extension,
-                                                 makestderr, stderrfilename,
-                                                 code_index_dict[key],
-                                                 engine_dict[family].errors,
-                                                 engine_dict[family].warnings,
-                                                 engine_dict[family].linenumbers,
-                                                 engine_dict[family].lookbehind,
-                                                 keeptemps, hashdependencies,
-                                                 pygments_settings]))
+                                                workingdir,
+                                                cc_dict_begin[family],
+                                                code_dict[key],
+                                                cc_dict_end[family],
+                                                engine_dict[family].language,
+                                                engine_dict[family].commands,
+                                                engine_dict[family].created,
+                                                engine_dict[family].extension,
+                                                makestderr, stderrfilename,
+                                                code_index_dict[key],
+                                                engine_dict[family].errors,
+                                                engine_dict[family].warnings,
+                                                engine_dict[family].linenumbers,
+                                                engine_dict[family].lookbehind,
+                                                keeptemps, hashdependencies,
+                                                pygments_settings)'''
+        tasks.append(async_or_eval('run_code', [encoding, outputdir,
+                                                workingdir,
+                                                cc_dict_begin[family],
+                                                code_dict[key],
+                                                cc_dict_end[family],
+                                                engine_dict[family].language,
+                                                engine_dict[family].commands,
+                                                engine_dict[family].created,
+                                                engine_dict[family].extension,
+                                                makestderr, stderrfilename,
+                                                code_index_dict[key],
+                                                engine_dict[family].errors,
+                                                engine_dict[family].warnings,
+                                                engine_dict[family].linenumbers,
+                                                engine_dict[family].lookbehind,
+                                                keeptemps, hashdependencies,
+                                                pygments_settings]))
         if verbose:
             print('    - Code process ' + key.replace('#', ':'))
 
@@ -1331,16 +1352,16 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
                            cc_dict_end[family], engine_dict[family].startup,
                            engine_dict[family].banner,
                            engine_dict[family].filename)'''
-            tasks.append(pool.apply_async(python_console, [jobname, encoding,
-                                                           outputdir, workingdir,
-                                                           fvextfile,
-                                                           pygments_settings[family] if family in pygments_settings else None,
-                                                           cc_dict_begin[family],
-                                                           cons_dict[key],
-                                                           cc_dict_end[family],
-                                                           engine_dict[family].startup,
-                                                           engine_dict[family].banner,
-                                                           engine_dict[family].filename]))
+            tasks.append(async_or_eval('python_console', [jobname, encoding,
+                                                          outputdir, workingdir,
+                                                          fvextfile,
+                                                          pygments_settings[family] if family in pygments_settings else None,
+                                                          cc_dict_begin[family],
+                                                          cons_dict[key],
+                                                          cc_dict_end[family],
+                                                          engine_dict[family].startup,
+                                                          engine_dict[family].banner,
+                                                          engine_dict[family].filename]))
         else:
             print('* PythonTeX error')
             print('    Currently, non-Python consoles are not supported')
@@ -1353,18 +1374,19 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
         # Uncomment the following for debugging
         # do_pygments(encoding, outputdir, fvextfile, pygments_list,
         #             pygments_settings, typeset_cache, hashdependencies)
-        tasks.append(pool.apply_async(do_pygments, [encoding, outputdir,
-                                                    fvextfile,
-                                                    pygments_list,
-                                                    pygments_settings,
-                                                    typeset_cache,
-                                                    hashdependencies]))
+        tasks.append(async_or_eval('do_pygments', [encoding, outputdir,
+                                                   fvextfile,
+                                                   pygments_list,
+                                                   pygments_settings,
+                                                   typeset_cache,
+                                                   hashdependencies]))
         if verbose:
             print('    - Pygments process')
 
     # Execute the processes
-    pool.close()
-    pool.join()
+    if multiprocessing:
+        pool.close()
+        pool.join()
 
     # Get the outputs of processes
     # Get the files and macros created.  Get the number of errors and warnings
@@ -1375,7 +1397,11 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
     new_files = False
     messages = []
     for task in tasks:
-        result = task.get()
+        if multiprocessing:
+            result = task.get()
+        else:
+            result = task
+
         if result['process'] == 'code':
             key = result['key']
             files[key].extend(result['files'])

--- a/pythontex/pythontex3.py
+++ b/pythontex/pythontex3.py
@@ -1299,7 +1299,7 @@ def do_multiprocessing(data, temp_data, old_data, engine_dict):
                                                  engine_dict[family].linenumbers,
                                                  engine_dict[family].lookbehind,
                                                  keeptemps, hashdependencies,
-                                                 pygments_settings]))'''
+                                                 pygments_settings)'''
         tasks.append(pool.apply_async(run_code, [encoding, outputdir,
                                                  workingdir,
                                                  cc_dict_begin[family],


### PR DESCRIPTION
Hi, 

Currently trying to run pythontex on android gives an error due to multiprocessing not working. There's been plenty of discussion on how to deal with this in other python projects, see for example https://github.com/pypa/pip/issues/8161.

With this PR we check if multiprocessing is supported and else set
multiprocessing=False. When later creating list of tasks to run we
then choose to either run pool.apply_async(function), or to just
eval(function).

<details>
  <summary>Error message when currently running pythontex</summary>

```
This is PythonTeX 0.17
Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/synchronize.py", line 28, in <module>
    from _multiprocessing import SemLock, sem_unlink
ImportError: cannot import name 'SemLock' from '_multiprocessing' (/data/data/com.termux/files/usr/lib/python3.8/lib-dynload/_multiprocessing.cpython-38.so)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/bin/texlive/pythontex", line 62, in <module>
    pythontex.main()
  File "/data/data/com.termux/files/usr/share/texlive/texmf-dist/scripts/pythontex/pythontex3.py", line 2811, in main
    do_multiprocessing(data, temp_data, old_data, engine_dict)
  File "/data/data/com.termux/files/usr/share/texlive/texmf-dist/scripts/pythontex/pythontex3.py", line 1269, in do_multiprocessing
    pool = multiprocessing.Pool(jobs)
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/pool.py", line 191, in __init__
    self._setup_queues()
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/pool.py", line 343, in _setup_queues
    self._inqueue = self._ctx.SimpleQueue()
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/context.py", line 113, in SimpleQueue
    return SimpleQueue(ctx=self.get_context())
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/queues.py", line 336, in __init__
    self._rlock = ctx.Lock()
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/context.py", line 67, in Lock
    from .synchronize import Lock
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/synchronize.py", line 30, in <module>
    raise ImportError("This platform lacks a functioning sem_open" +
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.
```

</details>

I have not updated pythontex2.py, mainly due to that 99 % of all users running into this problem will be using the terminal emulator termux (as I am) where python3 is already the default python version.

Let me know if you are not happy with the code format, associated comments or if I should fix something else in the commits!