### PR TITLE
fixed missing SubCodeEngine for javascript's js

### DIFF
--- a/pythontex/pythontex_engines.py
+++ b/pythontex/pythontex_engines.py
@@ -1748,3 +1748,4 @@ CodeEngine('javascript', 'javascript', '.js',
            ['error', 'Error'], ['warning', 'Warning'],
            ':{number}')
 
+SubCodeEngine('javascript', 'js')


### PR DESCRIPTION
Most other engines have a SubCodeEngine(langname, filesuffix)
to allow shorter macros to be used (\py instead of \python).
The documentation says the same is true for javascript, but
\js did not work prior to this commit.