### PR TITLE
Fix warning about \m by using raw docstring

### DIFF
--- a/pythontex/pythontex_utils.py
+++ b/pythontex/pythontex_utils.py
@@ -228,7 +228,7 @@ class PythonTeXUtils(object):
             
     # Finally, create the actual interface to SymPy's LatexPrinter
     def _make_sympy_latex(self):
-        '''
+        r'''
         Create a context-aware interface to SymPy's LatexPrinter class.
         
         This is an interface to the LatexPrinter class, rather than 


### PR DESCRIPTION
As suggested in

https://tex.stackexchange.com/questions/634981/pythontex-warning/640760

and reported on github as #196 -- the docstring contains latex
macros, but python interprets them as escape sequences. Use a python
raw string, r''' ... ''', in order to avoid this interpretation.